### PR TITLE
Refactor question storage functions

### DIFF
--- a/edubox_ar.py
+++ b/edubox_ar.py
@@ -1,15 +1,6 @@
 import cv2
-import json
-import os
 
-QUESTIONS_FILE = 'questions.json'
-
-
-def load_questions():
-    if not os.path.exists(QUESTIONS_FILE):
-        return []
-    with open(QUESTIONS_FILE, 'r', encoding='utf-8') as f:
-        return json.load(f)
+from question_store import load_questions
 
 
 def draw_question(frame, q):

--- a/edubox_gui.py
+++ b/edubox_gui.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 
-from teacher_interface import load_questions, save_questions
+from question_store import load_questions, save_questions
 from edubox_ar import run_quiz
 
 

--- a/question_store.py
+++ b/question_store.py
@@ -1,0 +1,18 @@
+import json
+import os
+
+QUESTIONS_FILE = 'questions.json'
+
+
+def load_questions():
+    """Load list of questions from QUESTIONS_FILE if it exists."""
+    if not os.path.exists(QUESTIONS_FILE):
+        return []
+    with open(QUESTIONS_FILE, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def save_questions(qs):
+    """Save list of questions to QUESTIONS_FILE."""
+    with open(QUESTIONS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(qs, f, indent=2)

--- a/teacher_interface.py
+++ b/teacher_interface.py
@@ -1,19 +1,4 @@
-import json
-import os
-
-QUESTIONS_FILE = 'questions.json'
-
-
-def load_questions():
-    if not os.path.exists(QUESTIONS_FILE):
-        return []
-    with open(QUESTIONS_FILE, 'r', encoding='utf-8') as f:
-        return json.load(f)
-
-
-def save_questions(qs):
-    with open(QUESTIONS_FILE, 'w', encoding='utf-8') as f:
-        json.dump(qs, f, indent=2)
+from question_store import load_questions, save_questions
 
 
 def add_question():


### PR DESCRIPTION
## Summary
- add `question_store.py` to hold question loading and saving logic
- import the shared module from `edubox_ar.py`, `teacher_interface.py`, and `edubox_gui.py`

## Testing
- `python -m py_compile edubox_ar.py teacher_interface.py edubox_gui.py question_store.py`

------
https://chatgpt.com/codex/tasks/task_e_68416e90e6d8832a8ead6c02685bdcbc